### PR TITLE
fix CMakeLists.txt for Ecc target and case-sensitivity in includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 *.app
 !Bison.exe
 !Flex.exe
+
+# CMake Build dirs (temp)
+Build/

--- a/Sources/Ecc/CMakeLists.txt
+++ b/Sources/Ecc/CMakeLists.txt
@@ -2,7 +2,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 PROJECT(Ecc)
 
 FILE(GLOB_RECURSE ECC_INCLUDES "*.h")
-FILE(GLOB_RECURSE ECC_SOURCES "*.cpp")
+# no recursing, as we then also add CMAKE-cpp stuff which we don't want.
+# this also would break the build as we'd have multiple main symbols.
+FILE(GLOB ECC_SOURCES "*.cpp")
 
 INCLUDE_DIRECTORIES ("../")
 ADD_EXECUTABLE (Ecc ${ECC_SOURCES} ${ECC_INCLUDES})

--- a/Sources/Engine/Base/Anim.cpp
+++ b/Sources/Engine/Base/Anim.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Anim.h>
 

--- a/Sources/Engine/Base/CRC.cpp
+++ b/Sources/Engine/Base/CRC.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 // Note: this CRC calculation algorithm, although originating from MSDN examples,
 // is in fact identical to the Adler32 used in ZIP's CRC calculation.

--- a/Sources/Engine/Base/CTString.cpp
+++ b/Sources/Engine/Base/CTString.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/CTString.h>
 #include <Engine/Base/Memory.h>

--- a/Sources/Engine/Base/Changeable.cpp
+++ b/Sources/Engine/Base/Changeable.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Changeable.h>
 #include <Engine/Base/ChangeableRT.h>

--- a/Sources/Engine/Base/Console.cpp
+++ b/Sources/Engine/Base/Console.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Base/Console_Internal.h>

--- a/Sources/Engine/Base/Directory.cpp
+++ b/Sources/Engine/Base/Directory.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/FileName.h>
 #include <Engine/Base/Unzip.h>

--- a/Sources/Engine/Base/ErrorReporting.cpp
+++ b/Sources/Engine/Base/ErrorReporting.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/ErrorReporting.h>
 #include <Engine/Base/ErrorTable.h>

--- a/Sources/Engine/Base/FileName.cpp
+++ b/Sources/Engine/Base/FileName.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/FileName.h>
 

--- a/Sources/Engine/Base/IFeel.cpp
+++ b/Sources/Engine/Base/IFeel.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/IFeel.h>
 #include <Engine/Base/FileName.h>
 #include <Engine/Base/Stream.h>

--- a/Sources/Engine/Base/Input.cpp
+++ b/Sources/Engine/Base/Input.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Timer.h>
 #include <Engine/Base/Input.h>

--- a/Sources/Engine/Base/Lists.cpp
+++ b/Sources/Engine/Base/Lists.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Lists.h>
 

--- a/Sources/Engine/Base/Memory.cpp
+++ b/Sources/Engine/Base/Memory.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Memory.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Base/Profiling.cpp
+++ b/Sources/Engine/Base/Profiling.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Profiling.h>
 

--- a/Sources/Engine/Base/Registry.cpp
+++ b/Sources/Engine/Base/Registry.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/CTString.h>
 #include <Engine/Base/FileName.h>
 #include <Engine/Base/Registry.h>

--- a/Sources/Engine/Base/Relations.cpp
+++ b/Sources/Engine/Base/Relations.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Relations.h>
 

--- a/Sources/Engine/Base/ReplaceFile.cpp
+++ b/Sources/Engine/Base/ReplaceFile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/ReplaceFile.h>
 #include <Engine/Base/Stream.h>

--- a/Sources/Engine/Base/Serial.cpp
+++ b/Sources/Engine/Base/Serial.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Serial.h>
 

--- a/Sources/Engine/Base/Shell.cpp
+++ b/Sources/Engine/Base/Shell.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Shell.h>
 #include <Engine/Base/Shell_internal.h>

--- a/Sources/Engine/Base/ShellTypes.cpp
+++ b/Sources/Engine/Base/ShellTypes.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Shell.h>
 #include <Engine/Base/Shell_internal.h>

--- a/Sources/Engine/Base/StackDump.cpp
+++ b/Sources/Engine/Base/StackDump.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console_Internal.h>
 

--- a/Sources/Engine/Base/Statistics.cpp
+++ b/Sources/Engine/Base/Statistics.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Statistics.h>
 #include <Engine/Base/Statistics_Internal.h>

--- a/Sources/Engine/Base/Stream.cpp
+++ b/Sources/Engine/Base/Stream.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <sys\types.h>
 #include <sys\stat.h>

--- a/Sources/Engine/Base/Timer.cpp
+++ b/Sources/Engine/Base/Timer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Timer.h>
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Base/Translation.cpp
+++ b/Sources/Engine/Base/Translation.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/CTString.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Base/Unzip.cpp
+++ b/Sources/Engine/Base/Unzip.cpp
@@ -16,7 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // unzip.cpp : Defines the entry point for the console application.
 //
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/FileName.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Base/Updateable.cpp
+++ b/Sources/Engine/Base/Updateable.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Updateable.h>
 #include <Engine/Base/UpdateableRT.h>

--- a/Sources/Engine/Brushes/Brush.cpp
+++ b/Sources/Engine/Brushes/Brush.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/World/World.h>

--- a/Sources/Engine/Brushes/BrushArchive.cpp
+++ b/Sources/Engine/Brushes/BrushArchive.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushArchive.h>

--- a/Sources/Engine/Brushes/BrushExport.cpp
+++ b/Sources/Engine/Brushes/BrushExport.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/World/WorldEditingProfile.h>

--- a/Sources/Engine/Brushes/BrushIO.cpp
+++ b/Sources/Engine/Brushes/BrushIO.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/ReplaceFile.h>

--- a/Sources/Engine/Brushes/BrushImport.cpp
+++ b/Sources/Engine/Brushes/BrushImport.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Math/Float.h>

--- a/Sources/Engine/Brushes/BrushMip.cpp
+++ b/Sources/Engine/Brushes/BrushMip.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/World/World.h>

--- a/Sources/Engine/Brushes/BrushPolygon.cpp
+++ b/Sources/Engine/Brushes/BrushPolygon.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushTransformed.h>

--- a/Sources/Engine/Brushes/BrushSector.cpp
+++ b/Sources/Engine/Brushes/BrushSector.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushTransformed.h>

--- a/Sources/Engine/Brushes/BrushShadows.cpp
+++ b/Sources/Engine/Brushes/BrushShadows.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushTransformed.h>

--- a/Sources/Engine/Brushes/BrushTriangularize.cpp
+++ b/Sources/Engine/Brushes/BrushTriangularize.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Templates/DynamicArray.cpp>

--- a/Sources/Engine/CMakeLists.txt
+++ b/Sources/Engine/CMakeLists.txt
@@ -5,5 +5,72 @@ PROJECT(Engine)
 FILE(GLOB_RECURSE ENGINE_INCLUDES "*.h")
 FILE(GLOB_RECURSE ENGINE_SOURCES "*.cpp")
 
-INCLUDE_DIRECTORIES ("../")
+INCLUDE_DIRECTORIES ("../" ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 ADD_EXECUTABLE (Engine ${ENGINE_SOURCES} ${ENGINE_INCLUDES})
+
+
+# - Try to find precompiled headers support for GCC 3.4 and 4.x
+# Once done this will define:
+#
+# Variable:
+#   PCHSupport_FOUND
+#
+# Macro:
+#   ADD_PRECOMPILED_HEADER
+
+IF(CMAKE_COMPILER_IS_GNUCXX)
+    EXEC_PROGRAM(
+    	${CMAKE_CXX_COMPILER} 
+        ARGS 			--version 
+        OUTPUT_VARIABLE _compiler_output)
+    STRING(REGEX REPLACE ".* ([0-9]\\.[0-9]\\.[0-9]) .*" "\\1" 
+           gcc_compiler_version ${_compiler_output})
+    #MESSAGE("GCC Version: ${gcc_compiler_version}")
+    IF(gcc_compiler_version MATCHES "4\\.[0-9]\\.[0-9]")
+        SET(PCHSupport_FOUND TRUE)
+    ELSE(gcc_compiler_version MATCHES "4\\.[0-9]\\.[0-9]")
+        IF(gcc_compiler_version MATCHES "3\\.4\\.[0-9]")
+            SET(PCHSupport_FOUND TRUE)
+        ENDIF(gcc_compiler_version MATCHES "3\\.4\\.[0-9]")
+    ENDIF(gcc_compiler_version MATCHES "4\\.[0-9]\\.[0-9]")
+ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+
+MACRO(ADD_PRECOMPILED_HEADER _targetName _input )
+
+    GET_FILENAME_COMPONENT(_name ${_input} NAME)
+    SET(_source "${CMAKE_CURRENT_SOURCE_DIR}/${_input}")
+    SET(_outdir "${CMAKE_CURRENT_BINARY_DIR}/${_name}.gch")
+    MAKE_DIRECTORY(${_outdir})
+    SET(_output "${_outdir}/${CMAKE_BUILD_TYPE}.c++")
+    STRING(TOUPPER "CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}" _flags_var_name)
+    SET(_compiler_FLAGS ${${_flags_var_name}})
+    
+    GET_DIRECTORY_PROPERTY(_directory_flags INCLUDE_DIRECTORIES)
+    FOREACH(item ${_directory_flags})
+    LIST(APPEND _compiler_FLAGS "-I${item}")
+    ENDFOREACH(item)
+
+	GET_DIRECTORY_PROPERTY(_directory_flags DEFINITIONS)
+    LIST(APPEND _compiler_FLAGS ${_directory_flags})
+
+    SEPARATE_ARGUMENTS(_compiler_FLAGS)
+    #MESSAGE("_compiler_FLAGS: ${_compiler_FLAGS}")
+    message("${CMAKE_CXX_COMPILER} ${_compiler_FLAGS} -x c++-header -o ${_output} ${_source}")
+    ADD_CUSTOM_COMMAND(
+        OUTPUT ${_output}
+        COMMAND ${CMAKE_CXX_COMPILER}
+				${_compiler_FLAGS}
+				-x c++-header
+				-o ${_output} ${_source}
+        DEPENDS ${_source} )
+   	ADD_CUSTOM_TARGET(${_targetName}_gch DEPENDS ${_output})
+    ADD_DEPENDENCIES(${_targetName} ${_targetName}_gch)
+    #SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-include ${_name} -Winvalid-pch -H")
+    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include ${_name} -Winvalid-pch")
+    SET_TARGET_PROPERTIES(${_targetName} PROPERTIES
+    	COMPILE_FLAGS "-include ${_name} -Winvalid-pch"
+    )
+	
+ENDMACRO(ADD_PRECOMPILED_HEADER)
+
+ADD_PRECOMPILED_HEADER (Engine StdH.h)

--- a/Sources/Engine/Entities/Entity.cpp
+++ b/Sources/Engine/Entities/Entity.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/Entity.h>
 #include <Engine/Entities/EntityClass.h>

--- a/Sources/Engine/Entities/EntityClass.cpp
+++ b/Sources/Engine/Entities/EntityClass.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Entities/EntityClass.h>

--- a/Sources/Engine/Entities/EntityCollision.cpp
+++ b/Sources/Engine/Entities/EntityCollision.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/Entity.h>
 #include <Engine/Entities/EntityCollision.h>

--- a/Sources/Engine/Entities/EntityCopying.cpp
+++ b/Sources/Engine/Entities/EntityCopying.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/Entity.h>
 #include <Engine/Entities/LastPositions.h>

--- a/Sources/Engine/Entities/EntityProperties.cpp
+++ b/Sources/Engine/Entities/EntityProperties.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/EntityProperties.h>
 #include <Engine/Entities/Precaching.h>

--- a/Sources/Engine/Entities/FieldBSPTesting.cpp
+++ b/Sources/Engine/Entities/FieldBSPTesting.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/Entity.h>
 #include <Engine/Entities/EntityCollision.h>

--- a/Sources/Engine/Entities/NearestPolygon.cpp
+++ b/Sources/Engine/Entities/NearestPolygon.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/Entity.h>
 #include <Engine/Brushes/Brush.h>

--- a/Sources/Engine/Entities/PlayerCharacter.cpp
+++ b/Sources/Engine/Entities/PlayerCharacter.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Entities/PlayerCharacter.h>
 #include <Engine/Base/Timer.h>

--- a/Sources/Engine/Graphics/Adapter.cpp
+++ b/Sources/Engine/Graphics/Adapter.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Adapter.h>
 #include <Engine/Graphics/GfxLibrary.h>

--- a/Sources/Engine/Graphics/Benchmark.cpp
+++ b/Sources/Engine/Graphics/Benchmark.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Base/Timer.h>

--- a/Sources/Engine/Graphics/Color.cpp
+++ b/Sources/Engine/Graphics/Color.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Color.h>
 #include <Engine/Math/Functions.h>

--- a/Sources/Engine/Graphics/DepthCheck.cpp
+++ b/Sources/Engine/Graphics/DepthCheck.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Graphics/DisplayMode.cpp
+++ b/Sources/Engine/Graphics/DisplayMode.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/DisplayMode.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Graphics/DrawPort.cpp
+++ b/Sources/Engine/Graphics/DrawPort.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/DrawPort.h>
 

--- a/Sources/Engine/Graphics/DrawPort_Particles.cpp
+++ b/Sources/Engine/Graphics/DrawPort_Particles.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/DrawPort.h>
 

--- a/Sources/Engine/Graphics/DrawPort_RenderScene.cpp
+++ b/Sources/Engine/Graphics/DrawPort_RenderScene.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/DrawPort.h>
 

--- a/Sources/Engine/Graphics/Font.cpp
+++ b/Sources/Engine/Graphics/Font.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Font.h>
 #include <Engine/Base/Stream.h>

--- a/Sources/Engine/Graphics/GfxLibrary.cpp
+++ b/Sources/Engine/Graphics/GfxLibrary.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/GfxLibrary.h>
 

--- a/Sources/Engine/Graphics/GfxProfile.cpp
+++ b/Sources/Engine/Graphics/GfxProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/GfxProfile.h>
 

--- a/Sources/Engine/Graphics/Gfx_Direct3D.cpp
+++ b/Sources/Engine/Graphics/Gfx_Direct3D.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Translation.h>
 #include <Engine/Base/ErrorReporting.h>

--- a/Sources/Engine/Graphics/Gfx_Direct3D_Colors.cpp
+++ b/Sources/Engine/Graphics/Gfx_Direct3D_Colors.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #ifdef SE1_D3D
 

--- a/Sources/Engine/Graphics/Gfx_Direct3D_Textures.cpp
+++ b/Sources/Engine/Graphics/Gfx_Direct3D_Textures.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #ifdef SE1_D3D
 

--- a/Sources/Engine/Graphics/Gfx_OpenGL.cpp
+++ b/Sources/Engine/Graphics/Gfx_OpenGL.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/GfxLibrary.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Graphics/Gfx_OpenGL_Textures.cpp
+++ b/Sources/Engine/Graphics/Gfx_OpenGL_Textures.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/GfxLibrary.h>
 

--- a/Sources/Engine/Graphics/Gfx_wrapper.cpp
+++ b/Sources/Engine/Graphics/Gfx_wrapper.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/GfxLibrary.h>
 #include <Engine/Graphics/ViewPort.h>

--- a/Sources/Engine/Graphics/Graphics.cpp
+++ b/Sources/Engine/Graphics/Graphics.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Statistics_internal.h>
 #include <Engine/Graphics/GfxLibrary.h>

--- a/Sources/Engine/Graphics/ImageInfo.cpp
+++ b/Sources/Engine/Graphics/ImageInfo.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/ImageInfo.h>
 #include <Engine/Graphics/Color.h>

--- a/Sources/Engine/Graphics/MultiMonitor.cpp
+++ b/Sources/Engine/Graphics/MultiMonitor.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <tchar.h>
 #include <Engine/Graphics/MultiMonitor.h>
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Graphics/Raster.cpp
+++ b/Sources/Engine/Graphics/Raster.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Raster.h>
 

--- a/Sources/Engine/Graphics/Shader.cpp
+++ b/Sources/Engine/Graphics/Shader.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/Stream.h>
 #include <Engine/Math/Projection.h>
 #include <Engine/Ska/Render.h>

--- a/Sources/Engine/Graphics/ShadowMap.cpp
+++ b/Sources/Engine/Graphics/ShadowMap.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/ShadowMap.h>
 

--- a/Sources/Engine/Graphics/Stereo.cpp
+++ b/Sources/Engine/Graphics/Stereo.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Stereo.h>
 

--- a/Sources/Engine/Graphics/Texture.cpp
+++ b/Sources/Engine/Graphics/Texture.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Texture.h>
 

--- a/Sources/Engine/Graphics/TextureEffects.cpp
+++ b/Sources/Engine/Graphics/TextureEffects.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Texture.h>
 #include <Engine/Graphics/TextureEffects.h>

--- a/Sources/Engine/Graphics/TextureRender.cpp
+++ b/Sources/Engine/Graphics/TextureRender.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/Texture.h>
 

--- a/Sources/Engine/Graphics/ViewPort.cpp
+++ b/Sources/Engine/Graphics/ViewPort.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Graphics/ViewPort.h>
 

--- a/Sources/Engine/Light/LayerMaker.cpp
+++ b/Sources/Engine/Light/LayerMaker.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Rendering/Render_internal.h>
 

--- a/Sources/Engine/Light/LayerMixer.cpp
+++ b/Sources/Engine/Light/LayerMixer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushTransformed.h>

--- a/Sources/Engine/Light/LightSource.cpp
+++ b/Sources/Engine/Light/LightSource.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushArchive.h>

--- a/Sources/Engine/Math/Float.cpp
+++ b/Sources/Engine/Math/Float.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Float.h>
 

--- a/Sources/Engine/Math/Functions.cpp
+++ b/Sources/Engine/Math/Functions.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Functions.h>
 

--- a/Sources/Engine/Math/Geometry.cpp
+++ b/Sources/Engine/Math/Geometry.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Geometry.h>
 

--- a/Sources/Engine/Math/Geometry_DOUBLE.cpp
+++ b/Sources/Engine/Math/Geometry_DOUBLE.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Geometry.h>
 

--- a/Sources/Engine/Math/Object3D.cpp
+++ b/Sources/Engine/Math/Object3D.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Object3D.h>
 

--- a/Sources/Engine/Math/Object3D_CSG.cpp
+++ b/Sources/Engine/Math/Object3D_CSG.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Object3D.h>
 #include <Engine/Templates/BSP_internal.h>

--- a/Sources/Engine/Math/Object3D_IO.cpp
+++ b/Sources/Engine/Math/Object3D_IO.cpp
@@ -16,7 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // If you happen to have the Exploration 3D library (in Engine/exploration3d/), you can enable its features here.
 #define USE_E3D 0
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Object3D.h>
 

--- a/Sources/Engine/Math/ObjectSector.cpp
+++ b/Sources/Engine/Math/ObjectSector.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Object3D.h>
 #include <Engine/Templates/BSP_internal.h>

--- a/Sources/Engine/Math/Placement.cpp
+++ b/Sources/Engine/Math/Placement.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Placement.h>
 

--- a/Sources/Engine/Math/Projection.cpp
+++ b/Sources/Engine/Math/Projection.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Projection.h>
 

--- a/Sources/Engine/Math/Projection_Isometric.cpp
+++ b/Sources/Engine/Math/Projection_Isometric.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Projection.h>
 

--- a/Sources/Engine/Math/Projection_Parallel.cpp
+++ b/Sources/Engine/Math/Projection_Parallel.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Projection.h>
 

--- a/Sources/Engine/Math/Projection_Perspective.cpp
+++ b/Sources/Engine/Math/Projection_Perspective.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Projection.h>
 

--- a/Sources/Engine/Math/Projection_Simple.cpp
+++ b/Sources/Engine/Math/Projection_Simple.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Projection.h>
 

--- a/Sources/Engine/Math/Projection_Simple_DOUBLE.cpp
+++ b/Sources/Engine/Math/Projection_Simple_DOUBLE.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Projection_DOUBLE.h>
 

--- a/Sources/Engine/Math/TextureMapping.cpp
+++ b/Sources/Engine/Math/TextureMapping.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/TextureMapping.h>
 

--- a/Sources/Engine/Models/EditModel.cpp
+++ b/Sources/Engine/Models/EditModel.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/ModelObject.h>
 #include <Engine/Models/ModelData.h>

--- a/Sources/Engine/Models/MipMaker.cpp
+++ b/Sources/Engine/Models/MipMaker.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/MipMaker.h>
 #include <Engine/Math/Vector.h>

--- a/Sources/Engine/Models/Model.cpp
+++ b/Sources/Engine/Models/Model.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/ModelObject.h>
 #include <Engine/Models/ModelData.h>

--- a/Sources/Engine/Models/ModelProfile.cpp
+++ b/Sources/Engine/Models/ModelProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/ModelProfile.h>
 

--- a/Sources/Engine/Models/Normals.cpp
+++ b/Sources/Engine/Models/Normals.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/Normals.h>
 #include <Engine/Math/Vector.h>

--- a/Sources/Engine/Models/RenderModel.cpp
+++ b/Sources/Engine/Models/RenderModel.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Statistics_internal.h>
 #include <Engine/Math/Float.h>

--- a/Sources/Engine/Models/RenderModel_Mask.cpp
+++ b/Sources/Engine/Models/RenderModel_Mask.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/ModelObject.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Models/RenderModel_View.cpp
+++ b/Sources/Engine/Models/RenderModel_View.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
- #include "stdh.h"
+ #include "StdH.h"
 
 #include <Engine/Base/Statistics_internal.h>
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Models/VertexGetting.cpp
+++ b/Sources/Engine/Models/VertexGetting.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Models/ModelObject.h>
 #include <Engine/Models/ModelData.h>

--- a/Sources/Engine/Network/ActionBuffer.cpp
+++ b/Sources/Engine/Network/ActionBuffer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Network/PlayerTarget.h>

--- a/Sources/Engine/Network/Buffer.cpp
+++ b/Sources/Engine/Network/Buffer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Math/Functions.h>
 #include <Engine/Base/Memory.h>

--- a/Sources/Engine/Network/CPacket.cpp
+++ b/Sources/Engine/Network/CPacket.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Base/ErrorReporting.h>

--- a/Sources/Engine/Network/ClientInterface.cpp
+++ b/Sources/Engine/Network/ClientInterface.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/CTString.h>
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Network/CommunicationInterface.cpp
+++ b/Sources/Engine/Network/CommunicationInterface.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Base/CTString.h>

--- a/Sources/Engine/Network/Compression.cpp
+++ b/Sources/Engine/Network/Compression.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Network/Compression.h>

--- a/Sources/Engine/Network/Diff.cpp
+++ b/Sources/Engine/Network/Diff.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/Timer.h>

--- a/Sources/Engine/Network/MessageDispatcher.cpp
+++ b/Sources/Engine/Network/MessageDispatcher.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Network/NetworkMessage.cpp
+++ b/Sources/Engine/Network/NetworkMessage.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Network/NetworkMessage.h>
 #include <Engine/Network/Compression.h>

--- a/Sources/Engine/Network/NetworkProfile.cpp
+++ b/Sources/Engine/Network/NetworkProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Network/NetworkProfile.h>
 

--- a/Sources/Engine/Network/Packet.cpp
+++ b/Sources/Engine/Network/Packet.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Base/ErrorReporting.h>

--- a/Sources/Engine/Network/PlayerBuffer.cpp
+++ b/Sources/Engine/Network/PlayerBuffer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Network/PlayerBuffer.h>

--- a/Sources/Engine/Network/PlayerSource.cpp
+++ b/Sources/Engine/Network/PlayerSource.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Network/Network.h>

--- a/Sources/Engine/Network/PlayerTarget.cpp
+++ b/Sources/Engine/Network/PlayerTarget.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Network/Network.h>

--- a/Sources/Engine/Network/Server.cpp
+++ b/Sources/Engine/Network/Server.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Build.h>
 #include <Engine/Network/Network.h>

--- a/Sources/Engine/Network/SessionState.cpp
+++ b/Sources/Engine/Network/SessionState.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Build.h>
 #include <Engine/Network/Network.h>

--- a/Sources/Engine/Rendering/Render.cpp
+++ b/Sources/Engine/Rendering/Render.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushTransformed.h>

--- a/Sources/Engine/Rendering/RenderProfile.cpp
+++ b/Sources/Engine/Rendering/RenderProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Rendering/RenderProfile.h>
 

--- a/Sources/Engine/Rendering/SelectOnRender.cpp
+++ b/Sources/Engine/Rendering/SelectOnRender.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Brushes/Brush.h>
 #include <Engine/Brushes/BrushTransformed.h>

--- a/Sources/Engine/Ska/Mesh.cpp
+++ b/Sources/Engine/Ska/Mesh.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include "Mesh.h"
 
 #define MESH_VERSION  12

--- a/Sources/Engine/Ska/ModelInstance.cpp
+++ b/Sources/Engine/Ska/ModelInstance.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Ska/ModelInstance.h>
 #include <Engine/Ska/Skeleton.h>
 #include <Engine/Ska/Render.h>

--- a/Sources/Engine/Ska/Skeleton.cpp
+++ b/Sources/Engine/Ska/Skeleton.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include "Skeleton.h"
 
 #include <Engine/Graphics/DrawPort.h>

--- a/Sources/Engine/Sound/SoundData.cpp
+++ b/Sources/Engine/Sound/SoundData.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Sound/SoundData.h>
 

--- a/Sources/Engine/Sound/SoundDecoder.cpp
+++ b/Sources/Engine/Sound/SoundDecoder.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Sound/SoundDecoder.h>
 #include <Engine/Base/Stream.h>

--- a/Sources/Engine/Sound/SoundLibrary.cpp
+++ b/Sources/Engine/Sound/SoundLibrary.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include "initguid.h"
 
 #include <Engine/Sound/SoundLibrary.h>

--- a/Sources/Engine/Sound/SoundMixer.cpp
+++ b/Sources/Engine/Sound/SoundMixer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Sound/SoundProfile.h>
 #include <Engine/Sound/SoundDecoder.h>

--- a/Sources/Engine/Sound/SoundObject.cpp
+++ b/Sources/Engine/Sound/SoundObject.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/Console.h>

--- a/Sources/Engine/Sound/SoundProfile.cpp
+++ b/Sources/Engine/Sound/SoundProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Sound/SoundProfile.h>
 

--- a/Sources/Engine/Sound/Wave.cpp
+++ b/Sources/Engine/Sound/Wave.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/ErrorReporting.h>

--- a/Sources/Engine/Templates/BSP.cpp
+++ b/Sources/Engine/Templates/BSP.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/BSP.h>
 #include <Engine/Templates/BSP_internal.h>

--- a/Sources/Engine/Templates/NameTable_CTFileName.cpp
+++ b/Sources/Engine/Templates/NameTable_CTFileName.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/FileName.h>
 

--- a/Sources/Engine/Templates/NameTable_CTranslationPair.cpp
+++ b/Sources/Engine/Templates/NameTable_CTranslationPair.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/TranslationPair.h>
 

--- a/Sources/Engine/Templates/Stock_CAnimData.cpp
+++ b/Sources/Engine/Templates/Stock_CAnimData.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CAnimData.h>
 

--- a/Sources/Engine/Templates/Stock_CAnimSet.cpp
+++ b/Sources/Engine/Templates/Stock_CAnimSet.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CAnimSet.h>
 

--- a/Sources/Engine/Templates/Stock_CEntityClass.cpp
+++ b/Sources/Engine/Templates/Stock_CEntityClass.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CEntityClass.h>
 

--- a/Sources/Engine/Templates/Stock_CMesh.cpp
+++ b/Sources/Engine/Templates/Stock_CMesh.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CMesh.h>
 

--- a/Sources/Engine/Templates/Stock_CModelData.cpp
+++ b/Sources/Engine/Templates/Stock_CModelData.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CModelData.h>
 

--- a/Sources/Engine/Templates/Stock_CShader.cpp
+++ b/Sources/Engine/Templates/Stock_CShader.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CShader.h>
 

--- a/Sources/Engine/Templates/Stock_CSkeleton.cpp
+++ b/Sources/Engine/Templates/Stock_CSkeleton.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CSkeleton.h>
 

--- a/Sources/Engine/Templates/Stock_CSoundData.cpp
+++ b/Sources/Engine/Templates/Stock_CSoundData.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CSoundData.h>
 

--- a/Sources/Engine/Templates/Stock_CTextureData.cpp
+++ b/Sources/Engine/Templates/Stock_CTextureData.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Templates/Stock_CTextureData.h>
 

--- a/Sources/Engine/Terrain/ArrayHolder.cpp
+++ b/Sources/Engine/Terrain/ArrayHolder.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Terrain/ArrayHolder.h>
 #include <Engine/Terrain/Terrain.h>
 #include <Engine/Terrain/TerrainMisc.h>

--- a/Sources/Engine/Terrain/Terrain.cpp
+++ b/Sources/Engine/Terrain/Terrain.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/ListIterator.inl>
 #include <Engine/Math/Projection.h>

--- a/Sources/Engine/Terrain/TerrainArchive.cpp
+++ b/Sources/Engine/Terrain/TerrainArchive.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Terrain/Terrain.h>
 #include <Engine/Terrain/TerrainArchive.h>

--- a/Sources/Engine/Terrain/TerrainEditing.cpp
+++ b/Sources/Engine/Terrain/TerrainEditing.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Terrain/Terrain.h>
 #include <Engine/Terrain/TerrainRender.h>
 #include <Engine/Terrain/TerrainEditing.h>

--- a/Sources/Engine/Terrain/TerrainLayer.cpp
+++ b/Sources/Engine/Terrain/TerrainLayer.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Base/Stream.h>
 #include <Engine/Base/ErrorReporting.h>
 #include <Engine/Base/Translation.h>

--- a/Sources/Engine/Terrain/TerrainMisc.cpp
+++ b/Sources/Engine/Terrain/TerrainMisc.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Math/Vector.h>
 #include <Engine/Math/Plane.h>
 #include <Engine/Math/Functions.h>

--- a/Sources/Engine/Terrain/TerrainRayCasting.cpp
+++ b/Sources/Engine/Terrain/TerrainRayCasting.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Terrain/Terrain.h>
 #include <Engine/Math/Plane.h>
 #include <Engine/Math/Clipping.inl>

--- a/Sources/Engine/Terrain/TerrainRender.cpp
+++ b/Sources/Engine/Terrain/TerrainRender.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Terrain/Terrain.h>
 #include <Engine/Terrain/TerrainRender.h>
 #include <Engine/Terrain/TerrainEditing.h>

--- a/Sources/Engine/Terrain/TerrainTile.cpp
+++ b/Sources/Engine/Terrain/TerrainTile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Terrain/TerrainTile.h>
 #include <Engine/Terrain/Terrain.h>
 #include <Engine/Terrain/TerrainRender.h>

--- a/Sources/Engine/World/PhysicsProfile.cpp
+++ b/Sources/Engine/World/PhysicsProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/World/PhysicsProfile.h>
 

--- a/Sources/Engine/World/World.cpp
+++ b/Sources/Engine/World/World.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/Math/Float.h>

--- a/Sources/Engine/World/WorldCSG.cpp
+++ b/Sources/Engine/World/WorldCSG.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/ErrorReporting.h>
 #include <Engine/World/World.h>

--- a/Sources/Engine/World/WorldEditingProfile.cpp
+++ b/Sources/Engine/World/WorldEditingProfile.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/World/WorldEditingProfile.h>
 

--- a/Sources/Engine/World/WorldIO.cpp
+++ b/Sources/Engine/World/WorldIO.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Stream.h>
 #include <Engine/Math/Float.h>

--- a/Sources/Engine/World/WorldRayCasting.cpp
+++ b/Sources/Engine/World/WorldRayCasting.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 #include <Engine/Base/Console.h>
 #include <Engine/World/World.h>

--- a/Sources/EngineGui/FileRequester.cpp
+++ b/Sources/EngineGui/FileRequester.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/Templates/Stock_CTextureData.h>
 
 // thumbnail window

--- a/Sources/SeriousSam/Credits.cpp
+++ b/Sources/SeriousSam/Credits.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 #include <Engine/CurrentVersion.h>
 #include "Credits.h"
 

--- a/Sources/SeriousSam/GLSettings.cpp
+++ b/Sources/SeriousSam/GLSettings.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
-#include "stdh.h"
+#include "StdH.h"
 
 // list of settings data
 static CListHead _lhSettings;


### PR DESCRIPTION
The file's called StdH.h not stdh.h