### PR TITLE
Another cmake fix

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,14 +1,13 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
+PROJECT(SeriousEngine)
+
 ADD_DEFINITIONS(-DPLATFORM_UNIX=1)
 ADD_DEFINITIONS(-D_MT=1)
-
-OPTION(USE_CLANG "Build application with clang" OFF) # OFF is the default
 
 IF(WIN32)
     SET (CMAKE_BUILD_TYPE None CACHE STRING "Set build type to None for windows") # Keep it blank for windows build?
 ELSE(WIN32)
-    MESSAGE(STATUS "You should be here")
     IF(NOT CMAKE_BUILD_TYPE)
 	SET (CMAKE_BUILD_TYPE Debug CACHE STRING 
 	    "Choose the type of build, options are : None Debug Release RelWithDebInfo MinSizeRel." 
@@ -16,16 +15,14 @@ ELSE(WIN32)
     ENDIF(NOT CMAKE_BUILD_TYPE)
 ENDIF(WIN32)
 
-IF(USE_CLANG) # Use clang/clang++
+IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") # Use clang/clang++
 
-    SET (CMAKE_C_COMPILER             "/usr/bin/clang")
     SET (CMAKE_C_FLAGS                "-Wall -std=c99")
     SET (CMAKE_C_FLAGS_DEBUG          "-g")
     SET (CMAKE_C_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
     SET (CMAKE_C_FLAGS_RELEASE        "-O3 -DNDEBUG")
     SET (CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g")
 
-    SET (CMAKE_CXX_COMPILER             "/usr/bin/clang++")
     SET (CMAKE_CXX_FLAGS                "-Wall -std=c++11")
     SET (CMAKE_CXX_FLAGS_DEBUG          "-g")
     SET (CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
@@ -33,9 +30,8 @@ IF(USE_CLANG) # Use clang/clang++
 
     SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 
-ELSE(USE_CLANG) # USE_CLANG) # Use gcc/g++
+ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # USE_CLANG) # Use gcc/g++
 
-    MESSAGE(STATUS "You should not be here")
     SET (CMAKE_C_FLAGS                "-Wall -std=c99")
     SET (CMAKE_C_FLAGS_DEBUG          "-g")
     SET (CMAKE_C_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
@@ -48,9 +44,7 @@ ELSE(USE_CLANG) # USE_CLANG) # Use gcc/g++
     SET (CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
     SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 
-ENDIF(USE_CLANG)
-
-PROJECT(SeriousEngine)
+ENDIF()
 
 # Looks like the engine depends on these projects at some point.
 # FIXME: For Windows, these are in Tools.Win32


### PR DESCRIPTION
CMakeLists.txt: As per instructions from #cmake on freenode I removed the ability to select
	a different compiler in CMakeLists.txt its self, you need to either
	select them on ubuntu as sudo update-alternitives --config c++ and
	select clang++ and sudo update-alternitives --config cc and select
	clang use the export CC=/usr/bin/clang export CXX=/usr/bin/clang++
	or cmake -DCMAKE_C_COMPILER=/usr/bin/clang
	-DCMAKE_CXX_COMPILER=/usr/bin/clang++ to select clang as your
	preferred compiler set. cmake does not support setting a different
	compiler tool chain in the CMakeLists.txt file as a regular var.